### PR TITLE
Fix part of the build GROUP=jdk.jar for checker-framework

### DIFF
--- a/asmx/src/org/objectweb/asmx/ClassReader.java
+++ b/asmx/src/org/objectweb/asmx/ClassReader.java
@@ -1760,12 +1760,13 @@ public class ClassReader {
             v = readAnnotationValue(v, buf, name, xav);
         }
 
-        // this is a workaround for
+        // Work around
         // https://bugs.openjdk.java.net/browse/JDK-8198945
-        // which has only been fixed in JDK 12
-        // the other part of this workaround is located at
+        // which has only been fixed in JDK 12, by not running the
+        // visitor if an invalid CLASS_EXTENDS is found in a method body.
+        // A similar workaround is located at
         // https://github.com/eisop/checker-framework/blob/abdb77758e6eb2dcb9dc569ff9f34341dda8b776/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java#L81
-        // which explains why it is TargetType.CLASS_EXTENDS here
+        // which explains why it is TargetType.CLASS_EXTENDS.
         if (!(isMethodBody && target_type == TargetType.CLASS_EXTENDS)) {
             xav.visitEnd();
         }

--- a/asmx/src/org/objectweb/asmx/ClassReader.java
+++ b/asmx/src/org/objectweb/asmx/ClassReader.java
@@ -1713,6 +1713,9 @@ public class ClassReader {
         // this is a workaround for
         // https://bugs.openjdk.java.net/browse/JDK-8198945
         // which has only been fixed in JDK 12
+        // the other part of this workaround is located at
+        // https://github.com/eisop/checker-framework/blob/abdb77758e6eb2dcb9dc569ff9f34341dda8b776/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java#L81
+        // which is why it is TargetType.CLASS_EXTENDS here
         if (!(is_method_extended_annotations && target_type == TargetType.CLASS_EXTENDS)) {
             xav.visitEnd();
         }

--- a/asmx/src/org/objectweb/asmx/ClassReader.java
+++ b/asmx/src/org/objectweb/asmx/ClassReader.java
@@ -1480,6 +1480,9 @@ public class ClassReader {
     *        {@link #readConst readConst}.
     * @param mv the visitor to generate the visitor that must visit the values.
     * @param visible {@code true} if the annotation is visible at runtime.
+    * @param is_method_extended_annotations {@code true} if this method is
+    *        called to read a method's extended annotations; need to be
+    *        {@code false} for all other cases.
     * @return the end offset of the annotations values.
     * @author jaimeq
     */
@@ -1707,6 +1710,9 @@ public class ClassReader {
             v = readAnnotationValue(v, buf, name, xav);
         }
 
+        // this is a workaround for
+        // https://bugs.openjdk.java.net/browse/JDK-8198945
+        // which has only been fixed in JDK 12
         if (!(is_method_extended_annotations && target_type == TargetType.CLASS_EXTENDS)) {
             xav.visitEnd();
         }

--- a/asmx/src/org/objectweb/asmx/ClassReader.java
+++ b/asmx/src/org/objectweb/asmx/ClassReader.java
@@ -323,7 +323,7 @@ public class ClassReader {
     /**
      * Copies the bootstrap method data into the given {@link ClassWriter}.
      * Should be called before the {@link #accept(ClassVisitor,int)} method.
-     * 
+     *
      * @param classWriter
      *            the {@link ClassWriter} to copy bootstrap methods into.
      */
@@ -629,7 +629,7 @@ public class ClassReader {
                 v += 2;
                 for (; j > 0; --j) {
                     v = readTypeAnnotationValues(v,
-                            c, classVisitor, i != 0);
+                            c, classVisitor, i != 0, false);
                 }
             }
         }
@@ -748,7 +748,7 @@ public class ClassReader {
                     v += 2;
                     for(; k > 0; --k) {
                         v = readTypeAnnotationValues(v,
-                            c, fv, true);
+                            c, fv, true, false);
                     }
                 }
 
@@ -758,7 +758,7 @@ public class ClassReader {
                     v += 2;
                     for(; k > 0; --k) {
                         v = readTypeAnnotationValues(v,
-                            c, fv, false);
+                            c, fv, false, false);
                     }
                 }
 
@@ -940,7 +940,7 @@ public class ClassReader {
                         w += 2;
                         for (; k > 0; --k) {
                             w = readTypeAnnotationValues(w,
-                                  c, mv, j != 0);
+                                  c, mv, j != 0, true);
                         }
                     }
                 }
@@ -1145,14 +1145,14 @@ public class ClassReader {
                         w = v + 8;
                         for (; k > 0; --k) {
                             w = readTypeAnnotationValues(w,
-                                    c, mv, false);
+                                    c, mv, false, false);
                         }
                     } else if (attrName.equals("RuntimeVisibleTypeAnnotations")) {
                         k = readUnsignedShort(v + 6);
                         w = v + 8;
                         for (; k > 0; --k) {
                             w = readTypeAnnotationValues(w,
-                                    c, mv, true);
+                                    c, mv, true, false);
                         }
                     } else {
                         for (k = 0; k < attrs.length; ++k) {
@@ -1487,7 +1487,8 @@ public class ClassReader {
         int v,
         final char[] buf,
         final MemberVisitor mv,
-        final boolean visible)
+        final boolean visible,
+        final boolean is_method_extended_annotations)
     {
         // first handle
         //
@@ -1706,7 +1707,9 @@ public class ClassReader {
             v = readAnnotationValue(v, buf, name, xav);
         }
 
-        xav.visitEnd();
+        if (!(is_method_extended_annotations && target_type == TargetType.CLASS_EXTENDS)) {
+            xav.visitEnd();
+        }
         return v;
     }
 
@@ -1868,7 +1871,7 @@ public class ClassReader {
 
     /**
      * Returns the start index of the attribute_info structure of this class.
-     * 
+     *
      * @return the start index of the attribute_info structure of this class.
      */
     private int getAttributes() {


### PR DESCRIPTION
Currently the build of checker-framework with `GROUP=jdk.jar` fails due to [JDK-8198945](https://bugs.openjdk.java.net/browse/JDK-8198945): extra type annotations are included in a method's description in the class file generated by JDK 9. The bug has been fixed in JDK 12, and this PR is a dirty workaround for it before JDK 9/10/11 are given up.

The idea is to let [ClassReader.readTypeAnnotationValues](https://github.com/eisop/annotation-tools/blob/master/asmx/src/org/objectweb/asmx/ClassReader.java#L1486) know if it is reading a method's extended type annotations, and if this is true, the reading is skipped.

This is implemented by adding a new parameter `is_method_extended_annotations` to `ClassReader.readTypeAnnotationValues` as a flag, and skip the final step of reading annotations if the flag is set and the `target_type` of the annotation is [CLASS_EXTENDS](https://github.com/eisop/checker-framework/blob/master/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java#L81).

With this fix, the task `:checker:buildJdk` in the build `GROUP=jdk.jar` that is causing the failure right now will succeed, but the build will still fail a later task for some other reason.
