### PR TITLE
Terminate insertion message after insertions

### DIFF
--- a/annotation-file-utilities/src/annotator/Main.java
+++ b/annotation-file-utilities/src/annotator/Main.java
@@ -954,7 +954,7 @@ public class Main {
         }
       }
       if (verbose && !debug && (num_insertions % 50) != 0) {
-        // after all insertions, we should terminate the line that contains dots
+        // after all insertions, if necessary, terminate the line that contains dots
         System.out.println();
       }
 

--- a/annotation-file-utilities/src/annotator/Main.java
+++ b/annotation-file-utilities/src/annotator/Main.java
@@ -953,6 +953,10 @@ public class Main {
           }
         }
       }
+      if (verbose && !debug && (num_insertions % 50) != 0) {
+        // after all insertions, we should terminate the line that contains dots
+        System.out.println();
+      }
 
       if (convert_jaifs) {
         for (Map.Entry<String, AScene> entry : scenes.entrySet()) {


### PR DESCRIPTION
For each insertion, we output a dot character in stdout, but we don't add a newline to terminate the dots after the insertions (ref: https://github.com/opprop/annotation-tools/blob/4c2eed5a8de566483dfa56166dbdaedaca79a14e/annotation-file-utilities/src/annotator/Main.java#L931).

For example, this is the current output:
```
Read 1 annotations from default.jaif
Processing A.java
Parsed A.java
getPositions returned 1 positions in tree for A.java
.Writing /Users/zcai/Developer/tests/java/twofiles/out/A.java
Processing B.java
Parsed B.java
getPositions returned 0 positions in tree for B.java
Writing /Users/zcai/Developer/tests/java/twofiles/out/B.java
```
which contains ".Writing".

In CFI, we need to monitor the lines starting with "Writing" to find out what files to type check in `ROUNDTRIP_TYPECHECK` mode (ref: https://github.com/opprop/checker-framework-inference/blob/07ca7254887bb9186dc9c8187cd8582554a3ce09/src/checkers/inference/InferenceLauncher.java#L366). The dot is causing some files to be ignored.

This PR should fix the above issue. It should not affect the current CFI tests because none of them is using `ROUNDTRIP_TYPECHECK` mode.
