### PR TITLE
Prepare for javac API changes to AST end positions

### DIFF
--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/Main.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/Main.java
@@ -426,7 +426,7 @@ public class Main {
                 int i = LocalVariableScanner.indexOfVarTree(path, varTree, rec.varName);
                 int m = methTree.getStartPosition();
                 int a = varTree.getStartPosition();
-                int b = varTree.getEndPosition(tree.endPositions);
+                int b = TreePathUtil.getEndPosition(varTree, tree);
                 LocalLocation loc = new LocalLocation(i, a - m, b - a);
                 decl = meth.body.locals.getVivify(loc);
                 break;

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/TreeFinder.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/find/TreeFinder.java
@@ -278,7 +278,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
               exp = jfa.getExpression();
               if (jfa.sym.isStatic()) {
                 return pathAndPos(
-                    exp, getFirstInstanceAfter('.', exp.getEndPosition(tree.endPositions)) + 1);
+                    exp, getFirstInstanceAfter('.', TreePathUtil.getEndPosition(exp, tree)) + 1);
               }
             } while (exp instanceof JCFieldAccess
                 && ((JCFieldAccess) exp).sym.getKind() != ElementKind.PACKAGE);
@@ -292,7 +292,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
               t = exp;
             }
             return pathAndPos(
-                t, getFirstInstanceAfter('.', t.getEndPosition(tree.endPositions)) + 1);
+                t, getFirstInstanceAfter('.', TreePathUtil.getEndPosition(t, tree)) + 1);
           case ARRAY_TYPE:
             t = ((JCArrayTypeTree) t).elemtype;
             break;
@@ -395,11 +395,11 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
           if (n < getDimsSize((JCExpression) parent)) { // else n == #dims
             i =
                 getNthInstanceInRange(
-                    '[', i, ((JCNewArray) parent).getEndPosition(tree.endPositions), n + 1);
+                    '[', i, TreePathUtil.getEndPosition(((JCNewArray) parent), tree), n + 1);
           }
         }
         if (i == null) {
-          i = jcnode.getEndPosition(tree.endPositions);
+          i = TreePathUtil.getEndPosition(jcnode, tree);
         }
       } else if (parent.getKind() == Tree.Kind.NEW_CLASS) { // NewClassTree)
         dbug.debug("TypePositionFinder.visitIdentifier: recognized class%n");
@@ -426,7 +426,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
     public IPair<ASTRecord, Integer> visitMemberSelect(MemberSelectTree node, Insertion ins) {
       dbug.debug("TypePositionFinder.visitMemberSelect(%s)%n", node);
       JCFieldAccess raw = (JCFieldAccess) node;
-      return IPair.of(astRecord(node), raw.getEndPosition(tree.endPositions) - raw.name.length());
+      return IPair.of(astRecord(node), TreePathUtil.getEndPosition(raw, tree) - raw.name.length());
     }
 
     @Override
@@ -514,7 +514,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
       int largestLevels = arrayLevels(largest);
       int levels = arrayLevels(node);
       int start = arrayContentType(att).getPreferredPosition() + 1;
-      int end = att.getEndPosition(tree.endPositions);
+      int end = TreePathUtil.getEndPosition(att, tree);
       int pos = arrayInsertPos(start, end);
 
       dbug.debug("  levels=%d largestLevels=%d%n", levels, largestLevels);
@@ -633,7 +633,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
       dbug.debug("TypePositionFinder.visitNewArray%n");
       JCNewArray na = (JCNewArray) node;
       GenericArrayLocationCriterion galc = ins.getCriteria().getGenericArrayLocation();
-      ASTRecord rec = ASTIndex.indexOf(tree).get(node);
+      ASTRecord rec = astRecord(node);
       ASTPath astPath = ins.getCriteria().getASTPath();
       String childSelector = null;
       // Invariant:  na.dims.size() == 0  or  na.elems == null  (but not both)
@@ -767,7 +767,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
         }
         if (na.dims.size() != 0) {
           int startPos = na.getStartPosition();
-          int endPos = na.getEndPosition(tree.endPositions);
+          int endPos = TreePathUtil.getEndPosition(na, tree);
           int pos = getNthInstanceInRange('[', startPos, endPos, dim + 1);
           return IPair.of(rec.replacePath(astPath), pos);
         }
@@ -1219,7 +1219,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
             pos = ((JCExpression) bound).getStartPosition();
             ((AnnotationInsertion) i).setGenerateBound(true);
           } else {
-            int limit = ((JCTree) parent(node)).getEndPosition(tree.endPositions);
+            int limit = TreePathUtil.getEndPosition(parent(node), tree);
             Integer nextpos1 = getNthInstanceInRange(',', pos + 1, limit, 1);
             Integer nextpos2 = getNthInstanceInRange('>', pos + 1, limit, 1);
             pos = (nextpos1 != Position.NOPOS && nextpos1 < nextpos2) ? nextpos1 : nextpos2;
@@ -1238,7 +1238,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
         }
       } else if (i.getKind() == Insertion.Kind.CLOSE_PARENTHESIS) {
         JCTree jcTree = (JCTree) node;
-        pos = jcTree.getEndPosition(tree.endPositions);
+        pos = TreePathUtil.getEndPosition(jcTree, tree);
       } else {
         boolean typeScan = true;
         if (node.getKind() == Tree.Kind.METHOD) { // MethodTree
@@ -1261,7 +1261,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
             && i.getKind() == Insertion.Kind.CONSTRUCTOR
             && (((JCMethodDecl) node).mods.flags & Flags.GENERATEDCONSTR) != 0) {
           Tree parent = path.getParentPath().getLeaf();
-          pos = ((JCClassDecl) parent).getEndPosition(tree.endPositions) - 1;
+          pos = TreePathUtil.getEndPosition(parent, tree) - 1;
           insertRecord = null; // TODO
         } else {
           // looking for the declaration
@@ -1360,8 +1360,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
       // in the source tree.  For example, a receiver annotation
       // matches on the method and inserts on the (possibly newly
       // created) receiver.
-      Map<Tree, ASTRecord> astIndex = ASTIndex.indexOf(tree);
-      ASTRecord insertRecord = astIndex.get(node);
+      ASTRecord insertRecord = astRecord(node);
       dbug.debug("TreeFinder.scan: node=%s%n  criteria=%s%n", node, i.getCriteria());
 
       if (TreePathUtil.hasClassKind(node)
@@ -1379,7 +1378,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
         }
         Tree parent = path.getParentPath().getLeaf();
         insertRecord = insertRecord.extend(Tree.Kind.METHOD, ASTPath.PARAMETER, -1);
-        pos = ((JCTree) parent).getEndPosition(tree.endPositions) - 1;
+        pos = TreePathUtil.getEndPosition(parent, tree) - 1;
       } else if (node.getKind() == Tree.Kind.METHOD && entry.childSelectorIs(ASTPath.TYPE)) {
         JCMethodDecl jcnode = (JCMethodDecl) node;
         Tree returnType = jcnode.getReturnType();
@@ -1419,7 +1418,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
             pos = ((JCExpression) bound).getStartPosition();
             ((AnnotationInsertion) i).setGenerateBound(true);
           } else {
-            int limit = ((JCTree) parent(node)).getEndPosition(tree.endPositions);
+            int limit = TreePathUtil.getEndPosition(parent(node), tree);
             Integer nextpos1 = getNthInstanceInRange(',', pos + 1, limit, 1);
             Integer nextpos2 = getNthInstanceInRange('>', pos + 1, limit, 1);
             pos = (nextpos1 != Position.NOPOS && nextpos1 < nextpos2) ? nextpos1 : nextpos2;
@@ -1462,7 +1461,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
           }
           jcTree = (JCTree) node;
         }
-        pos = jcTree.getEndPosition(tree.endPositions);
+        pos = TreePathUtil.getEndPosition(jcTree, tree);
       } else {
         boolean typeScan = true;
         if (node.getKind() == Tree.Kind.METHOD) { // MethodTree
@@ -1483,7 +1482,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
             && i.getKind() == Insertion.Kind.CONSTRUCTOR
             && (((JCMethodDecl) node).mods.flags & Flags.GENERATEDCONSTR) != 0) {
           Tree parent = path.getParentPath().getLeaf();
-          pos = ((JCClassDecl) parent).getEndPosition(tree.endPositions) - 1;
+          pos = TreePathUtil.getEndPosition(parent, tree) - 1;
           insertRecord = null; // TODO
         } else {
           // looking for the declaration
@@ -1514,7 +1513,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
     String name = cd.getSimpleName().toString();
     if (cd.typarams == null || cd.typarams.isEmpty()) {
       int start = cd.getStartPosition();
-      int offset = Math.max(start, mods.getEndPosition(tree.endPositions) + 1);
+      int offset = Math.max(start, TreePathUtil.getEndPosition(mods, tree) + 1);
       String s = cd.toString().substring(offset - start);
       Pattern p =
           Pattern.compile(
@@ -1532,7 +1531,7 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
       pos = offset + m.end() - 1;
     } else { // generic class
       JCTypeParameter param = cd.typarams.get(cd.typarams.length() - 1);
-      int start = param.getEndPosition(tree.endPositions);
+      int start = TreePathUtil.getEndPosition(param, tree);
       pos = getFirstInstanceAfter('>', start) + 1;
     }
     ((AnnotationInsertion) i).setGenerateExtends(true);
@@ -1556,13 +1555,13 @@ public class TreeFinder extends TreeScanner<Void, List<Insertion>> {
       return Position.NOPOS;
     }
     int nodeStart = node.getStartPosition();
-    int nodeEnd = node.getEndPosition(tree.endPositions);
+    int nodeEnd = TreePathUtil.getEndPosition(node, tree);
     int nodeLength = nodeEnd - nodeStart;
     int modsLength =
-        mods.getEndPosition(tree.endPositions)
+        TreePathUtil.getEndPosition(mods, tree)
             - mods.getStartPosition(); // can't trust string length!
     int bodyLength =
-        body == null ? 1 : body.getEndPosition(tree.endPositions) - body.getStartPosition();
+        body == null ? 1 : TreePathUtil.getEndPosition(body, tree) - body.getStartPosition();
     int start = nodeStart + modsLength;
     int end = nodeStart + nodeLength - bodyLength;
     int angle = name.lastIndexOf('>'); // check for type params

--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/scanner/TreePathUtil.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/annotator/scanner/TreePathUtil.java
@@ -1,5 +1,6 @@
 package org.checkerframework.afu.annotator.scanner;
 
+import com.google.common.base.Throwables;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
@@ -7,8 +8,13 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.tree.JCTree;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
 
 /** Utility methods relating to TreePaths. */
 public class TreePathUtil {
@@ -226,5 +232,64 @@ public class TreePathUtil {
       }
     }
     throw new Error("unreachable");
+  }
+
+  /**
+   * Returns the end position of the given tree, see {@link
+   * SourcePositions#getEndPosition(CompilationUnitTree, Tree)}.
+   *
+   * @param tree an AST node
+   * @param unit the compilation unit that contains {@code tree}
+   * @return the end position of the given tree
+   */
+  public static int getEndPosition(Tree tree, CompilationUnitTree unit) {
+    // This method has no `throws` clause, because of the `try` block.
+    try {
+      return (int) GET_END_POS_HANDLE.invokeExact((JCTree) tree, (JCTree.JCCompilationUnit) unit);
+    } catch (Throwable e) {
+      Throwables.throwIfUnchecked(e);
+      throw new AssertionError(e);
+    }
+  }
+
+  /** The {@link MethodHandle} for retrieving the end position of a {@link JCTree}. */
+  private static final MethodHandle GET_END_POS_HANDLE = getEndPosMethodHandle();
+
+  /**
+   * Returns the {@link MethodHandle} for retrieving the end position of a {@link JCTree}.
+   *
+   * @return the {@link MethodHandle} for retrieving the end position of a {@link JCTree}.
+   */
+  private static MethodHandle getEndPosMethodHandle() {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    try {
+      // JDK versions after https://bugs.openjdk.org/browse/JDK-8372948
+      // (tree, unit) -> tree.getEndPosition()
+      return MethodHandles.dropArguments(
+          lookup.findVirtual(JCTree.class, "getEndPosition", MethodType.methodType(int.class)),
+          1,
+          JCTree.JCCompilationUnit.class);
+    } catch (ReflectiveOperationException e1) {
+      // JDK versions before https://bugs.openjdk.org/browse/JDK-8372948
+      // (tree, unit) -> tree.getEndPosition(unit.endPositions)
+      try {
+        return MethodHandles.filterArguments(
+            lookup.findVirtual(
+                JCTree.class,
+                "getEndPosition",
+                MethodType.methodType(
+                    int.class, Class.forName("com.sun.tools.javac.tree.EndPosTable"))),
+            1,
+            lookup
+                .findVarHandle(
+                    JCTree.JCCompilationUnit.class,
+                    "endPositions",
+                    Class.forName("com.sun.tools.javac.tree.EndPosTable"))
+                .toMethodHandle(VarHandle.AccessMode.GET));
+      } catch (ReflectiveOperationException e2) {
+        e2.addSuppressed(e1);
+        throw new LinkageError(e2.getMessage(), e2);
+      }
+    }
   }
 }


### PR DESCRIPTION
After the upcoming changes in https://bugs.openjdk.org/browse/JDK-8372948, end positions will be stored directly in each `JCTree`, and the separate `EndPosTable` map will no longer exist.

This change uses method handles to support both versions of the internal API, before and after the changes in JDK-8372948.